### PR TITLE
[FE] Admin UI Layout Fix

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/.vercel

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
         "sweetalert2": "^11.4.26",
         "sweetalert2-react-content": "^5.0.2",
         "swr": "^1.3.0",
+        "use-persisted-state": "^0.3.3",
         "web-vitals": "^2.1.4",
         "yup": "^0.32.11"
       }
@@ -4886,6 +4887,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@use-it/event-listener": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@use-it/event-listener/-/event-listener-0.1.7.tgz",
+      "integrity": "sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -17030,6 +17039,17 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-persisted-state": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/use-persisted-state/-/use-persisted-state-0.3.3.tgz",
+      "integrity": "sha512-pCNlvYC8+XjRxwnIut4teGC9f2p9aD88R8OGseQGZa2dvqG/h1vEGk1vRE1IZG0Vf161UDpn+NlW4+UGubQflQ==",
+      "dependencies": {
+        "@use-it/event-listener": "^0.1.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -21330,6 +21350,12 @@
         "@typescript-eslint/types": "5.30.7",
         "eslint-visitor-keys": "^3.3.0"
       }
+    },
+    "@use-it/event-listener": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@use-it/event-listener/-/event-listener-0.1.7.tgz",
+      "integrity": "sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==",
+      "requires": {}
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -30044,6 +30070,14 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "use-persisted-state": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/use-persisted-state/-/use-persisted-state-0.3.3.tgz",
+      "integrity": "sha512-pCNlvYC8+XjRxwnIut4teGC9f2p9aD88R8OGseQGZa2dvqG/h1vEGk1vRE1IZG0Vf161UDpn+NlW4+UGubQflQ==",
+      "requires": {
+        "@use-it/event-listener": "^0.1.2"
       }
     },
     "util-deprecate": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "sweetalert2": "^11.4.26",
     "sweetalert2-react-content": "^5.0.2",
     "swr": "^1.3.0",
+    "use-persisted-state": "^0.3.3",
     "web-vitals": "^2.1.4",
     "yup": "^0.32.11"
   },

--- a/frontend/src/hooks/windowSize.js
+++ b/frontend/src/hooks/windowSize.js
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+
+const useWindowSize = (setDrawerState) => {
+  useEffect(() => {
+    const handleResize = () => {
+      window.innerWidth < 800 ? setDrawerState(false) : setDrawerState(true);
+    };
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+};
+
+export default useWindowSize;

--- a/frontend/src/pages/Admin/AdminLayout/AdminLayout.js
+++ b/frontend/src/pages/Admin/AdminLayout/AdminLayout.js
@@ -1,16 +1,20 @@
-import { useState } from "react";
 import { useLocation } from "react-router-dom";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import { Box, Container, CssBaseline, Grid, Toolbar } from "@mui/material";
+import createPersistedState from "use-persisted-state";
 
 import NavBar from "./NavBar";
 import SideBar from "./SideBar";
+import useWindowSize from "../../../hooks/windowSize";
+
+const useDrawerState = createPersistedState("drawerState");
 
 const mdTheme = createTheme();
 
-function Layout({ children, navTitle }) {
+const Layout = ({ children, navTitle }) => {
   const location = useLocation();
-  const [open, setOpen] = useState(location?.state?.open);
+  const [open, setOpen] = useDrawerState(location?.state?.open);
+  useWindowSize(setOpen);
 
   const toggleDrawer = () => {
     setOpen(!open);
@@ -54,8 +58,10 @@ function Layout({ children, navTitle }) {
       </Box>
     </ThemeProvider>
   );
-}
+};
 
-export default function AdminLayout({ children, navTitle }) {
+const AdminLayout = ({ children, navTitle }) => {
   return <Layout navTitle={navTitle}>{children}</Layout>;
-}
+};
+
+export default AdminLayout;

--- a/frontend/src/pages/Admin/AdminLayout/MenuItems.js
+++ b/frontend/src/pages/Admin/AdminLayout/MenuItems.js
@@ -1,9 +1,0 @@
-import { AccountCircle } from "@mui/icons-material";
-
-export const MenuItems = [
-  {
-    text: "Profile",
-    icon: <AccountCircle sx={{ marginRight: 1 }} />,
-    path: "/admin/profile",
-  },
-];

--- a/frontend/src/pages/Admin/AdminLayout/NavBar.js
+++ b/frontend/src/pages/Admin/AdminLayout/NavBar.js
@@ -1,29 +1,14 @@
-import { useState } from "react";
-
 import { styled } from "@mui/material/styles";
 import MuiAppBar from "@mui/material/AppBar";
-import {
-  Box,
-  IconButton,
-  Menu,
-  MenuItem,
-  Toolbar,
-  Tooltip,
-  Typography,
-  Avatar,
-  Skeleton,
-} from "@mui/material";
+import { IconButton, Toolbar, Typography } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
-import { Logout } from "@mui/icons-material";
-
-import { useAuth } from "../../../hooks/auth";
-import { MenuItems } from "./MenuItems";
 
 const DRAWER_WIDTH = 240;
 
 const AppBar = styled(MuiAppBar, {
   shouldForwardProp: (prop) => prop !== "open",
 })(({ theme, open }) => ({
+  zIndex: theme.zIndex.drawer - 3,
   transition: theme.transitions.create(["width", "margin"], {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.leavingScreen,
@@ -38,18 +23,7 @@ const AppBar = styled(MuiAppBar, {
   }),
 }));
 
-export default function NavBar({ open, toggleDrawer, navTitle }) {
-  const { user, logout } = useAuth({ middleware: "auth" });
-  const [anchorElUser, setAnchorElUser] = useState(null);
-
-  const handleOpenUserMenu = (event) => {
-    setAnchorElUser(event.currentTarget);
-  };
-
-  const handleCloseUserMenu = () => {
-    setAnchorElUser(null);
-  };
-
+const NavBar = ({ open, toggleDrawer, navTitle }) => {
   return (
     <AppBar position="absolute" open={open}>
       <Toolbar
@@ -78,45 +52,9 @@ export default function NavBar({ open, toggleDrawer, navTitle }) {
         >
           {navTitle}
         </Typography>
-        <Box sx={{ display: "flex", alignItems: "center" }}>
-          {!user ? (
-            <Skeleton variant="circular" width={40} height={40} />
-          ) : (
-            <Tooltip title={user?.name}>
-              <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
-                <Avatar alt={user?.name} src={user?.avatar?.url} />
-              </IconButton>
-            </Tooltip>
-          )}
-        </Box>
       </Toolbar>
-      <Menu
-        sx={{ mt: "45px" }}
-        id="menu-appbar"
-        anchorEl={anchorElUser}
-        anchorOrigin={{
-          vertical: "top",
-          horizontal: "right",
-        }}
-        keepMounted
-        transformOrigin={{
-          vertical: "top",
-          horizontal: "right",
-        }}
-        open={Boolean(anchorElUser)}
-        onClose={handleCloseUserMenu}
-      >
-        {MenuItems.map((item) => (
-          <MenuItem key={item.text} onClick={handleCloseUserMenu}>
-            {item.icon}
-            <Typography variant="span">{item.text}</Typography>
-          </MenuItem>
-        ))}
-        <MenuItem onClick={logout}>
-          <Logout sx={{ marginRight: 1 }} />
-          <Typography variant="span">Logout</Typography>
-        </MenuItem>
-      </Menu>
     </AppBar>
   );
-}
+};
+
+export default NavBar;

--- a/frontend/src/pages/Admin/AdminLayout/SideBar.js
+++ b/frontend/src/pages/Admin/AdminLayout/SideBar.js
@@ -5,15 +5,17 @@ import {
   Divider,
   IconButton,
   List,
+  ListItem,
+  ListItemAvatar,
   ListItemButton,
   ListItemIcon,
   ListItemText,
+  Skeleton,
   Toolbar,
   Typography,
 } from "@mui/material";
 import { School, ChevronLeft } from "@mui/icons-material";
-
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { MainListItems, SecondaryListItems } from "./ListItems";
 import { useAuth } from "../../../hooks/auth";
@@ -26,6 +28,7 @@ const Drawer = styled(MuiDrawer, {
   shouldForwardProp: (prop) => prop !== "open",
 })(({ theme, open }) => ({
   "& .MuiDrawer-paper": {
+    zIndex: theme.zIndex.drawer - 4,
     position: "relative",
     whiteSpace: "nowrap",
     width: DRAWER_WIDTH,
@@ -41,7 +44,7 @@ const Drawer = styled(MuiDrawer, {
         duration: theme.transitions.duration.leavingScreen,
       }),
       width: theme.spacing(7),
-      [theme.breakpoints.up("sm")]: {
+      [theme.breakpoints.up("xs")]: {
         width: theme.spacing(9),
       },
     }),
@@ -54,8 +57,8 @@ const SideBarListItems = styled(ListItemButton)(({ path, location }) => ({
 
 export default function SideBar({ open, toggleDrawer }) {
   const navigate = useNavigate();
-  const location = useLocation();
-  const { logout } = useAuth({ middleware: "auth" });
+  const { user, logout } = useAuth({ middleware: "auth" });
+  const { name, type, avatar } = user || {};
   const [loading, setLoading] = useState(false);
 
   const handleClick = () => {
@@ -74,7 +77,7 @@ export default function SideBar({ open, toggleDrawer }) {
           px: [1],
         }}
       >
-        <Avatar sx={{ m: 1, bgcolor: "primary.main" }}>
+        <Avatar sx={{ mr: 1, bgcolor: "primary.main" }}>
           <School />
         </Avatar>
         <Typography sx={{ fontWeight: "bold" }}>E-Learning System</Typography>
@@ -84,12 +87,36 @@ export default function SideBar({ open, toggleDrawer }) {
       </Toolbar>
       <Divider />
       <List component="nav">
+        {!user ? (
+          <ListItem>
+            <ListItemIcon>
+              <Skeleton variant="circular" width={40} height={40} />
+            </ListItemIcon>
+            <ListItemText
+              primary={<Skeleton variant="text" sx={{ fontSize: "1rem" }} />}
+              secondary={
+                <Skeleton
+                  variant="text"
+                  width="50%"
+                  sx={{ fontSize: "1rem" }}
+                />
+              }
+            />
+          </ListItem>
+        ) : (
+          <ListItem>
+            <ListItemAvatar>
+              <Avatar alt={name} src={avatar.url} />
+            </ListItemAvatar>
+            <ListItemText primary={name} secondary={type.name} />
+          </ListItem>
+        )}
+        <Divider />
         {MainListItems.map((item) => (
           <SideBarListItems
             key={item.text}
-            onClick={() => navigate(item.path, { state: { open: open } })}
+            onClick={() => navigate(item.path)}
             path={item.path}
-            location={location?.pathname}
           >
             <ListItemIcon>{item.icon}</ListItemIcon>
             <ListItemText primary={item.text} />


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1202627219907014/1202818757162208/f

## Definition of Done
- [x] Installed [use-persisted-state](https://www.npmjs.com/package/use-persisted-state) for persisting a state in a page
- [x] FIX: Made Sidebar/Drawer Persist depending whether it is open or not after refreshing
- [x] FIX: Close Side/Drawer when window width size reaches 800px and below
- [x] FIX: Remove authenticated user profile in the navbar and moved it in the sidebar.

## Notes
- Made some code cleanup while fixing the said tasks

## Screenshots/Recordings
- Admin Sidebar/Drawer

[persist-sidebar.webm](https://user-images.githubusercontent.com/108660012/185758657-db8e2eda-3b5d-4d86-b573-f77e1b0b68c5.webm)

- Admin name and avatar in sidebar

![auth-sidebar](https://user-images.githubusercontent.com/108660012/185758946-8f3f5b44-81fd-4fa8-9a0b-28b1a5bc2b7f.png)
 